### PR TITLE
BF: made due.py PEP8 compliant and harmonized some indentations in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,28 +19,28 @@ share it with others, test it, document it, and track its evolution.
 
 The project has the following structure:
 
-	shablona -
-			  |- `README.md`
-			  |- shablona
-					|- `__init__.py`
-					|- `shablona.py`
-					|- data
-						|- ...
-					|- tests
-						|- ...
-			  |- doc
-					|- `Makefile`
-					|- `conf.py`
-					|- sphinxext
-						|- ...
-					|- _static
-						|- ...
-			  |- `setup.py`
-			  |- `.travis.yml`
-			  |- `appveyor.yml`
-			  |- `LICENSE`
-			  |- ipynb
-		  			|- ...
+    shablona/
+      |- README.md
+      |- shablona/
+         |- __init__.py
+         |- shablona.py
+         |- data/
+            |- ...
+         |- tests/
+            |- ...
+      |- doc/
+         |- Makefile
+         |- conf.py
+         |- sphinxext/
+            |- ...
+         |- _static/
+            |- ...
+      |- setup.py
+      |- .travis.yml
+      |- appveyor.yml
+      |- LICENSE
+      |- ipynb/
+         |- ...
 
 
 In the following sections we will examine these elements one by one. First,
@@ -84,8 +84,8 @@ In this case, the project data is rather small, and recorded in csv files. Thus,
 Either way, you can create a `shablona/data` folder in which you can organize the data. As you can see in the test scripts, and in the analysis scripts, this provides a standard file-system location for the data at:
 
     import os.path as op
-	  import shablona as sb
-	  data_path = op.join(sb.__path__[0], 'data')
+    import shablona as sb
+    data_path = op.join(sb.__path__[0], 'data')
 
 
 ### Testing
@@ -335,7 +335,7 @@ To use this repository as a template, start by cloning it to your own computer u
 
 To point to your own repository on github you will have to issue something like the following:
 
-    git remote rm origin
+	git remote rm origin
 	git remote add origin https://github.com/arokem/smallish
 
 (replace `arokem` with your own Github user name).

--- a/shablona/__init__.py
+++ b/shablona/__init__.py
@@ -1,2 +1,2 @@
-from .shablona import *  # noqa
 from .version import __version__  # noqa
+from .shablona import *  # noqa

--- a/shablona/due.py
+++ b/shablona/due.py
@@ -1,12 +1,12 @@
-# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
-# ex: set sts=4 ts=4 sw=4 noet:
-# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+# emacs: at the end of the file
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
 """
 
-Stub file for a guaranteed safe import of duecredit constructs:  if duecredit is
-not available.
+Stub file for a guaranteed safe import of duecredit constructs:  if duecredit
+is not available.
 
-To use it, just place it into your project codebase to be imported, e.g. copy as
+To use it, place it into your project codebase to be imported, e.g. copy as
 
     cp stub.py /path/tomodule/module/due.py
 
@@ -17,18 +17,15 @@ Then use in your code as
 
     from .due import due, Doi, BibTeX
 
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
 
-Examples
---------
-
-TODO
-
-
-License:
-Originally a part of the duecredit, which is distributed under BSD-2 license.
+Origin:     Originally a part of the duecredit
+Copyright:  2015-2016  DueCredit developers
+License:    BSD-2
 """
 
-__version__ = '0.0.4'
+__version__ = '0.0.5'
+
 
 class InactiveDueCreditCollector(object):
     """Just a stub at the Collector which would not do anything"""
@@ -39,22 +36,24 @@ class InactiveDueCreditCollector(object):
     def dcite(self, *args, **kwargs):
         """If I could cite I would"""
         def nondecorating_decorator(func):
-             return func
+            return func
         return nondecorating_decorator
 
-    cite = load = add =  _donothing
+    cite = load = add = _donothing
 
     def __repr__(self):
         return self.__class__.__name__ + '()'
+
 
 def _donothing_func(*args, **kwargs):
     """Perform no good and no bad"""
     pass
 
 try:
-    from duecredit import *
+    from duecredit import due, BibTeX, Doi, Url
     if 'due' in locals() and not hasattr(due, 'cite'):
-        raise RuntimeError("Imported due lacks .cite. DueCredit is now disabled")
+        raise RuntimeError(
+            "Imported due lacks .cite. DueCredit is now disabled")
 except Exception as e:
     if type(e).__name__ != 'ImportError':
         import logging
@@ -63,3 +62,11 @@ except Exception as e:
     # Initiate due stub
     due = InactiveDueCreditCollector()
     BibTeX = Doi = Url = _donothing_func
+
+# Emacs mode definitions
+# Local Variables:
+# mode: python
+# py-indent-offset: 4
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:

--- a/shablona/shablona.py
+++ b/shablona/shablona.py
@@ -2,15 +2,19 @@ import numpy as np
 import pandas as pd
 import scipy.optimize as opt
 from scipy.special import erf
-from .due import due, Doi, BibTeX
+from .due import due, Doi
 
 __all__ = ["Model", "Fit", "opt_err_func", "transform_data", "cumgauss"]
 
 
 # Use duecredit (duecredit.org) to provide a citation to relevant work to
-# be cited. This does nothing, unless the user has duecredit installted,
+# be cited. This does nothing, unless the user has duecredit installed,
 # And calls this with duecredit (as in `python -m duecredit script.py`):
-due.cite(Doi("10.1167/13.9.30"))
+due.cite(Doi("10.1167/13.9.30"),
+         description="Template project for small scientific Python projects",
+         tags=["reference-implementation"],
+         path='shablona')
+
 
 def transform_data(data):
     """


### PR DESCRIPTION
meanwhile quickly pushed 0.4.6 release of duecredit with fixed up due.py to pypi
we are still to make it windows-compatible apparently (added appveyor config which showed some failing tests)

README.md still contains tabs in some text blocks -- didn't want to 'fix' where it wasn't really broken but you might want to uniformize
I also adjusted the tree listing so it become abit more "cohesive" (also was a mix of tabs and spaces and imho those ` were not necessary) ;-)
